### PR TITLE
localized date metatag

### DIFF
--- a/forms-bridge/includes/class-form-bridge.php
+++ b/forms-bridge/includes/class-form-bridge.php
@@ -834,17 +834,17 @@ class Form_Bridge {
 				$locale       = get_locale();
 				return $translations[ $locale ]['native_name'] ?? $locale;
 			case 'datetime':
-				return date( 'Y-m-d H:i:s', time() );
+				return wp_date( 'Y-m-d H:i:s' );
 			case 'gmt_datetime':
-				return gmdate( 'Y-m-d H:i:s', time() );
+				return gmdate( 'Y-m-d H:i:s' );
 			case 'timestamp':
 				return time();
 			case 'iso_date':
-				return date( 'c', time() );
+				return wp_date( 'c' );
 			case 'gmt_iso_date':
-				return gmdate( 'c', time() );
+				return gmdate( 'c' );
 			case 'utc_date':
-				$date = gmdate( 'c', time() );
+				$date = gmdate( 'c' );
 				return preg_replace( '/\+\d+\:\d+$/', 'Z', $date );
 			case 'user_id':
 				return wp_get_current_user()->ID;


### PR DESCRIPTION
Date metatags works with built-in PHP function [date](https://www.php.net/manual/en/function.date.php). This function is affected by runtime timezones.

At the same time, WordPress has the `timezone_string` and `gmt_offset` options to allow WordPress timezone to be decoupled from system timezones, and functions like [wp_date](https://developer.wordpress.org/reference/functions/wp_date/) to get localized dates.

This PR switches from built-in date functions to WP date functions to make date metatags compliant with the WordPress timezone. 

---
In response to [The Meta Tag “datetime” outputs UTC Time instead of the time in my time zone](https://wordpress.org/support/topic/the-meta-tag-datetime-outputs-utc-time-instead-of-the-time-in-my-time-zone/).

